### PR TITLE
Handle exact alarm scheduling permissions

### DIFF
--- a/mobile/android/app/src/main/kotlin/com/example/stem_sprouts/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/com/example/stem_sprouts/MainActivity.kt
@@ -1,5 +1,47 @@
 package com.example.stem_sprouts
 
+import android.app.AlarmManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.Settings
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val channelName = "stem_sprouts/alarm_permissions"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "canScheduleExactAlarms" -> result.success(canScheduleExactAlarms())
+                "requestExactAlarmPermission" -> result.success(requestExactAlarmPermission())
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun canScheduleExactAlarms(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+
+        val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        return alarmManager.canScheduleExactAlarms()
+    }
+
+    private fun requestExactAlarmPermission(): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return true
+        if (canScheduleExactAlarms()) return true
+
+        val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM).apply {
+            data = Uri.parse("package:$packageName")
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+
+        startActivity(intent)
+        return false
+    }
+}

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -21,7 +21,6 @@ import 'pages/settings_page.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await NotificationService().init();
-  await NotificationService().scheduleDailyNotification();
   runApp(const MyApp());
 }
 
@@ -51,6 +50,28 @@ class RootScaffold extends StatefulWidget {
 
 class _RootScaffoldState extends State<RootScaffold> {
   int _index = 0; // 0: Home, 1: Tutor, 2: Progress, 3: Settings
+  final NotificationService _notificationService = NotificationService();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _scheduleDailyReminder());
+  }
+
+  Future<void> _scheduleDailyReminder() async {
+    final result = await _notificationService.scheduleDailyNotification();
+
+    if (!mounted || result.message == null) {
+      return;
+    }
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(result.message!),
+        duration: const Duration(seconds: 5),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/mobile/lib/services/notifications.dart
+++ b/mobile/lib/services/notifications.dart
@@ -1,10 +1,15 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
-import 'package:flutter_timezone/flutter_timezone.dart';
 
 class NotificationService {
   static final NotificationService _notificationService = NotificationService._internal();
+  static const MethodChannel _alarmChannel = MethodChannel('stem_sprouts/alarm_permissions');
 
   factory NotificationService() {
     return _notificationService;
@@ -15,7 +20,8 @@ class NotificationService {
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
   Future<void> init() async {
-    const AndroidInitializationSettings initializationSettingsAndroid = AndroidInitializationSettings('@mipmap/ic_launcher'); // Notification icon
+    const AndroidInitializationSettings initializationSettingsAndroid =
+        AndroidInitializationSettings('@mipmap/ic_launcher'); // Notification icon
     const InitializationSettings initializationSettings = InitializationSettings(android: initializationSettingsAndroid);
 
     await flutterLocalNotificationsPlugin.initialize(initializationSettings);
@@ -30,21 +36,90 @@ class NotificationService {
     tz.setLocalLocation(tz.getLocation(timeZoneName));
   }
 
-  Future<void> scheduleDailyNotification() async {
+  Future<NotificationScheduleResult> scheduleDailyNotification() async {
+    bool canUseExactAlarm = await _canUseExactAlarms();
+
+    if (!canUseExactAlarm && Platform.isAndroid) {
+      try {
+        final bool permissionGranted = await _alarmChannel.invokeMethod<bool>('requestExactAlarmPermission') ?? false;
+        if (permissionGranted) {
+          canUseExactAlarm = await _canUseExactAlarms();
+        }
+      } catch (err, stack) {
+        debugPrint('Failed to request exact alarm permission: $err');
+        debugPrint('$stack');
+      }
+    }
+
+    final AndroidScheduleMode scheduleMode =
+        canUseExactAlarm ? AndroidScheduleMode.exactAllowWhileIdle : AndroidScheduleMode.inexactAllowWhileIdle;
+
+    try {
+      await _scheduleNotification(scheduleMode);
+      return NotificationScheduleResult(
+        scheduled: true,
+        requiresUserAction: !canUseExactAlarm,
+        message: canUseExactAlarm
+            ? 'Daily reminder scheduled successfully.'
+            : 'Daily reminder scheduled inexactly. Enable exact alarms for more reliable alerts.',
+      );
+    } on PlatformException catch (err, stack) {
+      debugPrint('Exact alarm scheduling failed, attempting fallback: $err');
+      debugPrint('$stack');
+
+      if (canUseExactAlarm) {
+        try {
+          await _scheduleNotification(AndroidScheduleMode.inexactAllowWhileIdle);
+          return NotificationScheduleResult(
+            scheduled: true,
+            requiresUserAction: true,
+            message: 'Exact alarms unavailable. Scheduled an inexact reminder instead.',
+          );
+        } on PlatformException catch (fallbackErr, fallbackStack) {
+          debugPrint('Inexact fallback also failed: $fallbackErr');
+          debugPrint('$fallbackStack');
+        }
+      }
+
+      return NotificationScheduleResult(
+        scheduled: false,
+        requiresUserAction: true,
+        message: 'Unable to schedule reminder. Please enable exact alarms in system settings.',
+      );
+    }
+  }
+
+  Future<void> _scheduleNotification(AndroidScheduleMode androidScheduleMode) async {
     await flutterLocalNotificationsPlugin.zonedSchedule(
-        0,
-        'Stem Sprouts Reminder',
-        'Don\'t forget to get your daily dose of learning in!',
-        _nextInstanceOfTenAM(),
-        const NotificationDetails(
-          android: AndroidNotificationDetails(
-            'daily_notification_channel_id',
-            'Daily Notifications',
-            channelDescription: 'Daily notifications to remind you to study',
-          ),
+      0,
+      'Stem Sprouts Reminder',
+      'Don\'t forget to get your daily dose of learning in!',
+      _nextInstanceOfTenAM(),
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          'daily_notification_channel_id',
+          'Daily Notifications',
+          channelDescription: 'Daily notifications to remind you to study',
         ),
-        androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
-        matchDateTimeComponents: DateTimeComponents.time);
+      ),
+      androidScheduleMode: androidScheduleMode,
+      matchDateTimeComponents: DateTimeComponents.time,
+    );
+  }
+
+  Future<bool> _canUseExactAlarms() async {
+    if (!Platform.isAndroid) {
+      return true;
+    }
+
+    try {
+      final bool? canSchedule = await _alarmChannel.invokeMethod<bool>('canScheduleExactAlarms');
+      return canSchedule ?? true;
+    } catch (err, stack) {
+      debugPrint('Failed to check exact alarm capability: $err');
+      debugPrint('$stack');
+      return true;
+    }
   }
 
   tz.TZDateTime _nextInstanceOfTenAM() {
@@ -55,4 +130,16 @@ class NotificationService {
     }
     return scheduledDate;
   }
+}
+
+class NotificationScheduleResult {
+  const NotificationScheduleResult({
+    required this.scheduled,
+    required this.requiresUserAction,
+    this.message,
+  });
+
+  final bool scheduled;
+  final bool requiresUserAction;
+  final String? message;
 }


### PR DESCRIPTION
## Summary
- add platform-channel exact alarm permission checks and fallbacks around daily reminder scheduling
- defer daily notification scheduling until after app start and surface user-facing status messages
- expose Android exact alarm capability checks and settings redirect through MainActivity

## Testing
- dart format lib *(fails: dart binary unavailable in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e5ff8c9b0832d94612629dd4d7f25)